### PR TITLE
Remove ym4r and add geocoder.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'json'
-gem 'ym4r'
+gem 'geocoder'
 
 group :development, :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.1.2)
+    geocoder (1.1.9)
     json (1.5.1)
     multi_json (1.7.9)
     rake (0.9.6)
@@ -20,16 +21,15 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    ym4r (0.6.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  geocoder
   json
   rake
   rcov
   rspec (>= 2.6.0)
   simplecov
   simplecov-rcov
-  ym4r

--- a/README.textile
+++ b/README.textile
@@ -20,9 +20,9 @@ h2. Installation
 The following gems are required:
 
 * json
-* ym4r
+* geocoder
 
-@$ sudo gem install json ym4r@
+@$ sudo gem install json geocoder@
 
 Then, install the gem:
 

--- a/doc/files/README_textile.html
+++ b/doc/files/README_textile.html
@@ -114,12 +114,12 @@ The following gems are required:
 <li>json
 
 </li>
-<li>ym4r
+<li>geocoder
 
 </li>
 </ul>
 <p>
-@$ sudo gem install json ym4r@
+@$ sudo gem install json geocoder@
 </p>
 <p>
 Then, install the <a href="../classes/Sunlight.html">Sunlight</a> gem:

--- a/doc/files/lib/sunlight_rb.html
+++ b/doc/files/lib/sunlight_rb.html
@@ -76,7 +76,7 @@
       rubygems&nbsp;&nbsp;
       json&nbsp;&nbsp;
       cgi&nbsp;&nbsp;
-      ym4r/google_maps/geocoding&nbsp;&nbsp;
+      geocoder&nbsp;&nbsp;
       </div>
     </div>
 

--- a/lib/sunlight.rb
+++ b/lib/sunlight.rb
@@ -1,9 +1,8 @@
 require 'json'
 require 'cgi'
-require 'ym4r/google_maps/geocoding'
+require 'geocoder'
 require 'net/http'
 require 'time'
-include Ym4r::GoogleMaps
 
 require "#{File.dirname(__FILE__)}/sunlight/base.rb"
 Dir["#{File.dirname(__FILE__)}/sunlight/*.rb"].each { |source_file| require source_file }

--- a/lib/sunlight/district.rb
+++ b/lib/sunlight/district.rb
@@ -23,7 +23,7 @@ module Sunlight
       elsif (params[:address])
 
         # get the lat/long from Google
-        placemarks = Geocoding::get(params[:address])
+        placemarks = Geocoder.search(params[:address])
 
         unless placemarks.empty?
           placemark = placemarks[0]

--- a/spec/district_spec.rb
+++ b/spec/district_spec.rb
@@ -23,10 +23,7 @@ describe Sunlight::District do
     end
 
     it "should return one record when valid street address is passed in" do
-      mock_placemark = mock Geocoding::Placemark
-      mock_placemark.should_receive(:latitude).and_return(123.45)
-      mock_placemark.should_receive(:longitude).and_return(-123.45)
-      Geocoding.should_receive(:get).and_return([mock_placemark])
+
       Sunlight::District.should_receive(:get_from_lat_long).and_return(Sunlight::District.new('NJ', '05'))
 
       district = Sunlight::District.get(:address => "123 Main St New York New York 10108")

--- a/spec/fixtures/geocoder/google_data.json
+++ b/spec/fixtures/geocoder/google_data.json
@@ -1,0 +1,63 @@
+{
+   "results" : [
+      {
+         "address_components" : [
+            {
+               "long_name" : "1600",
+               "short_name" : "1600",
+               "types" : [ "street_number" ]
+            },
+            {
+               "long_name" : "Amphitheatre Pkwy",
+               "short_name" : "Amphitheatre Pkwy",
+               "types" : [ "route" ]
+            },
+            {
+               "long_name" : "Mountain View",
+               "short_name" : "Mountain View",
+               "types" : [ "locality", "political" ]
+            },
+            {
+               "long_name" : "Santa Clara",
+               "short_name" : "Santa Clara",
+               "types" : [ "administrative_area_level_2", "political" ]
+            },
+            {
+               "long_name" : "California",
+               "short_name" : "CA",
+               "types" : [ "administrative_area_level_1", "political" ]
+            },
+            {
+               "long_name" : "United States",
+               "short_name" : "US",
+               "types" : [ "country", "political" ]
+            },
+            {
+               "long_name" : "94043",
+               "short_name" : "94043",
+               "types" : [ "postal_code" ]
+            }
+         ],
+         "formatted_address" : "1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA",
+         "geometry" : {
+            "location" : {
+               "lat" : 37.42291810,
+               "lng" : -122.08542120
+            },
+            "location_type" : "ROOFTOP",
+            "viewport" : {
+               "northeast" : {
+                  "lat" : 37.42426708029149,
+                  "lng" : -122.0840722197085
+               },
+               "southwest" : {
+                  "lat" : 37.42156911970850,
+                  "lng" : -122.0867701802915
+               }
+            }
+         },
+         "types" : [ "street_address" ]
+      }
+   ],
+   "status" : "OK"
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
 require File.dirname(__FILE__) + '/../lib/sunlight'
+
+Dir["./spec/support/**/*.rb"].sort.each {|f| require f}

--- a/spec/support/geocoder.rb
+++ b/spec/support/geocoder.rb
@@ -1,0 +1,25 @@
+module Geocoder
+  module Lookup
+    class Base
+      private
+      def read_fixture(file)
+        File.read(File.join("spec", "fixtures", "geocoder", file)).strip.gsub(/\n\s*/, "")
+      end
+    end
+
+    class Google < Base
+      private
+      def fetch_raw_data(query, reverse = false)
+        raise TimeoutError if query == "timeout"
+        raise SocketError if query == "socket_error"
+        file = case query
+          when "no results";   :no_results
+          when "no locality";  :no_locality
+          when "no city data"; :no_city_data
+          else                 :madison_square_garden
+        end
+        read_fixture "google_data.json"
+      end
+    end
+  end
+end

--- a/sunlight.gemspec
+++ b/sunlight.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |s|
              'lib/sunlight/district.rb', 'lib/sunlight/legislator.rb',
              'lib/sunlight/committee.rb', 'README.textile', 'CHANGES.textile']
   s.add_dependency("json", [">= 1.1.3"])
-  s.add_dependency("ym4r", [">= 0.6.1"])
+  s.add_dependency("geocoder", [">= 1.1.9"])
   s.has_rdoc = true
 end


### PR DESCRIPTION
I was having issues using any queries that required an address field. The stacktrace was showing an issue with ym4r. Since ym4r doesn't look like its being maintained, I replaced the gem with geocoder. All tests now pass and the address queries work fine.  

```
 OpenURI::HTTPError:
   403 Forbidden
 # ./lib/sunlight/district.rb:26:in `get'
 # ./lib/sunlight/legislator.rb:71:in `all_for'
 # ./spec/legislator_spec.rb:91:in `block (3 levels) in <top (required)>'
```
